### PR TITLE
Format character name bolding

### DIFF
--- a/Skin_Bones_Treatment_v1_WIP_Corrected.md
+++ b/Skin_Bones_Treatment_v1_WIP_Corrected.md
@@ -1,0 +1,497 @@
+# Skin & Bones - Treatment v1 WIP
+
+## **<u>ACT ONE</u>**
+
+### *Opening Scene*
+
+OVER BLACK, we hear **LENA BAKER**'s voice:
+
+> <mark>"I don't want to die fat."</mark> *[p. 537]*
+
+We fade into a fluorescent-lit clinic. **LENA BAKER** (39), carries herself with quiet strength that barely contains the storm beneath. She sits beside her mother, **HONEY** (60s)—both women stylish, though Honey's fit, sculpted frame and trendy outfit make them look more like sisters than mother and daughter. Honey's fingers drum against her designer purse, more impatient than nervous. While Lena's jaw tightens with each tap, Honey's expression remains composed, a master of the art of feeling nothing too deeply.
+
+**LENA (V.O.)**
+
+> <mark>"There would no doubt be whispers at the repast: It's too bad she didn't take better care of herself. They will speculate, assume. Diabetes? Heart attack?"</mark> *[p. 539]*
+
+A nurse calls them back—wafer-thin, the type who looks like she'd blow away in a strong wind. In the exam room. The standard-issue gown barely covers Lena's body. The blood pressure cuff won't fit. A larger one is fetched. Lena's hands clench the exam table's edge, knuckles lightening. Her engagement ring catches the harsh fluorescent light.
+
+**HONEY** comments on Lena's ashy elbows, wondering why she couldn't at least put lotion on before coming here. **LENA** twists her engagement ring like a talisman, already retreating into herself. **HONEY** suggests cutting bread before the wedding—no bread, no spread, that's what she always says. **LENA** asks if they can not do this here.
+
+**LENA (V.O.)**
+
+> <mark>"She calls it love. Some days it feels like being chiseled down, piece by piece, until there's nothing left."</mark> *[p. 540]*
+
+On the nurse's tablet screen, we glimpse her typing:
+
+> <mark>"Morbidly obese but seems happy. Dressed well, good hygiene."</mark> *[p. 565]*
+
+As if happiness in Lena's body is a medical anomaly worth noting.
+
+When the doctor finally enters, **LENA** explains she's here for a bladder infection—she's had them since childhood, knows the symptoms. Her voice wavers slightly, betraying the effort to stay calm. But he immediately pivots to diabetes testing and weight loss plans, despite her normal test results. She mentions trying to get GLP-1 medications covered by insurance but being denied. The irony: she's fat enough to need help, but not diabetic enough to deserve it. As a single mother, the out-of-pocket costs are impossible.
+
+Throughout this, **HONEY** nods along pleasantly, as if they're discussing the weather rather than her daughter's body. Her emotional thermostat never shifts.
+
+The doctor suggests appetite suppressants instead. Then, awkwardly, as if offering a consolation prize:
+
+> <mark>"You know, you are a beautiful woman. Your skin, your hair—just gorgeous."</mark>
+
+**LENA** tries once more to redirect to her actual medical concern, her voice rising just slightly—a wave threatening to break. Her fingers find the ring again, spinning it around and around. **HONEY** places a manicured hand on Lena's arm, a gesture that looks supportive but feels like a warning: *Control yourself.* The doctor's already leaving, promising to send antibiotics to her pharmacy, reminding her about that five to ten percent weight loss goal. Only after he's gone does the nurse finally brings a cup for the urine sample Lena's been holding this entire appointment.
+
+As mother and daughter leave the clinic, Lena catches her reflection in the glass doors. The words follow her out like a shadow:
+
+> "Morbidly obese but seems happy."
+
+Honey glides past the same reflection without a glance, untouched by what it might reveal.
+
+**LENA (V.O.)**
+
+> <mark>"Everything about me is big and Black. Big and majestic like the ocean. Every bit of me hard to contain."</mark> *[p. 561]*
+
+She stands a little taller as they walk to the car, her ring catching sunlight now instead of fluorescents—a small promise of something better. Carrying what is not hers to carry, but carrying it nonetheless.
+
+### *Introduction to Portland*
+
+After the clinic, Lena drives through Portland with Honey in the passenger seat. They pass the Pearl District's gleaming towers where warehouses once stood. Cross the Burnside Bridge, the Willamette River brown below. Through Albina, past empty lots where Black families once lived before urban renewal renamed removal as progress. A tent city sprawls under the freeway overpass—the new displaced alongside the old absences.
+
+**LENA (V.O.)**
+
+> "Portland pretends we were never here, but we've always been here. In the soil, in the stories, in the spaces they try to erase."
+
+Moving boxes line the hallway of Lena's craftsman home in Jade District—labeled "Master Bedroom," "AALIYAH's Room," "Kitchen." **KENDRA** has transformed the living room into a makeshift fitting room. **AALIYAH** stands on a step stool in her flower girl dress—soft lavender tulle that pulls across her middle.
+
+**KENDRA** tugs gently at the zipper. It won't close the last two inches.
+
+**LENA** notices immediately. The dress fit perfectly two months ago. She opens her mouth, then closes it, choosing her words carefully.
+
+> It needs to be let out, she tells **KENDRA**. Just a bit.
+
+**HONEY** reaches into her purse and pulls out a homemade cookie wrapped in a napkin. She hands it to Aaliyah with a wink, telling her:
+
+> it's for being such a good girl during the fitting.
+
+**LENA** stares.
+
+> Mom, really? Right now?
+
+**HONEY** waves her off.
+
+> She's a growing girl. One cookie won't hurt anything.
+
+**LENA (V.O.)**
+
+> "The same woman who monitored every bite I took, who locked cabinets and counted crackers, now sneaks my daughter sweets like they're sharing a secret that doesn't include me."
+
+While adjusting **LENA**'s hem, **KENDRA** mentions she's deleted the apps again.
+
+> "These men act like I should be grateful they're even willing to consider me. One actually said he 'doesn't usually date big girls' but I seem 'worth it.'"
+
+**LENA** tells her:
+
+> to delete him from existence.
+
+**KENDRA** already has. She asks:
+
+> if **MALCOLM** has any friends.
+
+**LENA** explains:
+
+> **MALCOLM** barely has **MALCOLM**—work and home, says three friends is plenty.
+
+She checks her phone.
+
+> He's picking her up at seven for dinner tonight.
+
+**KENDRA** teases her:
+
+> about enjoying these date nights while they last. Once you move in together after the wedding, it's all Netflix and sweatpants.
+
+**LENA** says:
+
+> she's ready for that. Ready for the whole thing—Saturday morning pancakes, helping with homework at the same kitchen table, Malcolm teaching Aaliyah to ride her bike in their driveway. A real family this time.
+
+**AALIYAH** pipes up, asking:
+
+> if her art table can come to Malcolm's house.
+
+> Of course, baby. Everything comes with us.
+
+**HONEY** mentions:
+
+> how much she likes Malcolm's neighborhood—those big trees, the park nearby. It'll be good for all of them.
+
+### *Upscale Restaurant - Evening*
+
+**MALCOLM** and **LENA** enter the softly lit restaurant. He'd called ahead requesting a table, not a booth—the kind of detail he handles without making it a thing.
+
+The hostess, all of twenty-two with a practiced smile, gestures toward the back.
+
+> <mark>"Right this way."</mark> *[p. 1168]*
+
+She stops at a booth. The narrow, fixed-seat booth with a table that doesn't move. **LENA**'s body tenses slightly.
+
+**MALCOLM**'s voice stays pleasant but firm:
+
+> He requested a table when he made the reservation.
+
+The hostess checks her tablet, insists:
+
+> no tables are available.
+
+They can both see empty tables in the front section.
+
+> Those tables? That section isn't open yet.
+
+**MALCOLM** looks at the clearly set tables, the lit candles. He takes **LENA**'s hand.
+
+> They're leaving.
+
+The hostess scrambles, suddenly finding she might be able to accommodate them after all, but **MALCOLM**'s already guiding **LENA** toward the door. Other diners watch, some sympathetic, most just curious about the minor drama.
+
+### *Pioneer Square Food Trucks - Later*
+
+They sit on the wide brick steps that double as benches, the same spot as their first date. **LENA**'s hips spread comfortably, taking up the space they need. They share spicy roasted shrimp sandwiches from the Korean-fusion truck, truffle fries from another.
+
+**MALCOLM** admits:
+
+> he was so nervous that first time, October last year, checking the weather app every five minutes, worried about rain ruining everything.
+
+**LENA** laughs.
+
+> You had three backup plans. A whole PowerPoint presentation of date alternatives.
+
+**MALCOLM** says:
+
+> Aaliyah's been asking if they can paint her new room purple. Deep purple, not lavender. Very serious about the distinction.
+
+> Of course. Their house should feel like home for both of them.
+
+He pauses.
+
+> All three of them, actually. He's been thinking about officially adopting Aaliyah after the wedding, if **LENA**'s comfortable with that. If Aaliyah wants it.
+
+**LENA**'s eyes fill. She doesn't trust her voice for a moment. **BRYAN** sees Aaliyah twice a year, sends checks when he remembers. Malcolm's been more of a father in two years than Bryan's been in eight. She manages a yes, then has to look away, overwhelmed.
+
+**MALCOLM** squeezes her hand.
+
+> No rush. Just wanted her to know he's all in.
+
+**LENA** wipes her eyes, laughs at herself for crying.
+
+> She's happy. All the pieces that seemed impossible to put together are coming together. The Vanport funding came through. Six weeks to pull it off—right after the wedding, they'll have to jump back in. But she's so excited. She's been dying to show him where it'll go in the museum. Does he want to see it?
+
+### *Museum - Night*
+
+**LENA**'s keycard beeps in the after-hours silence. The museum's main hall opens before them, street light filtering through tall windows. She leads **MALCOLM** to the east wing—her domain.
+
+The Vanport exhibit space is still being constructed. Partial walls, display cases waiting to be filled. **LENA** walks him through it quickly—here's where her grandfather's salvaged church pews will go. There, photographs from before the flood.
+
+> Eighteen thousand people displaced in a single afternoon. Grandaddy's church was never rebuilt, but those pews survived. They'll anchor the whole exhibit.
+
+**MALCOLM** mentions:
+
+> the oral histories his students have been collecting for her, the community elders ready to share their stories.
+
+**LENA** stands in the empty space where the pews will be installed.
+
+> In six weeks, the whole city will finally know what happened here. What was lost. What survived.
+
+**MALCOLM** pulls her close.
+
+> For so long, Portland pretended Black folks were never here. But this exhibit—it's going to take up all this space. Make them remember we've always been here.
+
+### *Lena's House - Later*
+
+**MALCOLM** walks **LENA** to her front porch. **HONEY**'s on the porch swing with her iPad, looking regal even in the porch light.
+
+**MALCOLM** hands her a to-go container.
+
+> Mac and cheese from that soul food truck. The one with the smoked gouda.
+
+**HONEY** takes a bite, savors it.
+
+> Finally, someone who pays attention.
+
+She looks at them both.
+
+> You two are good together. Don't let anyone tell you different.
+
+**AALIYAH** appears in the doorway in pajamas. **LENA** starts to protest but **HONEY** waves her off.
+
+> Let the child say goodnight to her soon-to-be daddy.
+
+**MALCOLM** kneels for **AALIYAH**'s hug. She whispers something that makes him smile.
+
+After quick goodnights, **MALCOLM** heads to his car. **HONEY** touches **LENA**'s arm before going inside—a brief moment of unexpected tenderness.
+
+This is her family. Imperfect, complicated, but hers.
+
+### *Wedding Day - Lena's House - Morning*
+
+The house hums with preparation. **KENDRA** does **LENA**'s makeup while **HONEY** helps **AALIYAH** with her flower girl dress.
+
+**MALCOLM** arrives. He needs to speak to **LENA** urgently. **KENDRA** and **HONEY** try to block him—bad luck to see the bride—but he insists. Through her bedroom door, he confesses:
+
+> right after their fight last year, when they reconciled, he never told her the whole truth. He slept with someone else. Just once. He wants no secrets between them at the altar.
+
+Behind the door, **LENA** goes completely still. When she finally speaks, her voice is eerily calm:
+
+> You let me plan this wedding. You let me trust you again.
+
+> I know. I'm sorry. I—
+
+**LENA** emerges in her wedding gown.
+
+> The wedding's off, Malcolm. We're done.
+
+**HONEY** shifts into crisis management.
+
+> Don't make rash decisions. Two hundred guests are on their way. Think of Aaliyah. Just go through with it today, deal with this after.
+
+But **LENA** won't marry someone who could lie to her for a year.
+
+**KENDRA** steps between them, protective.
+
+> You need to leave. Now.
+
+After he's gone, **HONEY** begins making calls—church, venue, vendors. Two hundred guests to notify.
+
+**AALIYAH** appears on the stairs, crying.
+
+> Is Malcolm not going to be my daddy anymore? Are we not moving to the new house?
+
+> No, baby. We're not moving. We're staying right here.
+
+**LENA** holds her daughter, both of them still in their wedding finery, the future they'd planned dissolving around them.
+
+### *Post-Wedding*
+
+The house empties slowly. **HONEY** takes **AALIYAH** with her—at least something for her is sure and consistent in this moment. **KENDRA** and **ASPEN** make their calls, cancel reservations, handle the logistics **LENA** can't bear to think about. They move about, talking, talking, talking. Words blur and circle around, bees stinging her, paralyzing her.
+
+> You need your space right now. Change out of that dress. We'll be back. We love you. You'll get through this. You will be okay. You don't need him. You got us. We got you.
+
+And then, silence.
+
+**LENA** stands in the doorway, still in her wedding gown, unable to move. The weight of what just happened presses down on her chest like a physical thing. She stares at the hardwood floors she was so proud of when she bought this house, the kitchen she loved—the floors, the island, the window at the sink.
+
+The wedding cake sits untouched on the kitchen counter. Three tiers of perfection that will never be cut at a reception. She approaches it slowly, like it might bite her.
+
+She cuts one thin slice from the top tier—decadent chocolate. It's as good as it was at the taste testing. That makes her wonder about the second tier, the specialty flavor, the bougie part of them—an Earl Grey sponge with fig filling. The third and biggest tier, vanilla bean cake with marionberry filling, even better than she remembers.
+
+Three slices.
+
+She pours milk into a wine glass—a gift from their engagement party. Still in her gown, she sits on the kitchen floor and eats, her dress spilling out all over the hardwood. The phone rings and chimes and alerts her of missed calls, voicemails, and text messages. She stares at the grain in the wood, remembers how proud she was of herself when she purchased her own home.
+
+An hour later, still in her dress, she makes tea. Earl Grey with a splash of half-and-half. And another slice of cake. She sits back down on the kitchen floor, lets the sweetness of the cake and comfort of the tea calm her.
+
+She tells herself over and over:
+
+> <mark>"This will not break you. This will not break you."</mark> *[p. 1830]*
+
+She gets up to cut herself another slice, then catches herself. She dumps the rest of the cake in the trash can.
+
+> <mark>"This will not break you," she tells herself.</mark> *[p. 1830]*
+
+The only thing still intact is the wedding topper. And that, she throws across the room. It shatters.
+
+Friends divide into camps—some supporting Malcolm's honesty, others condemning his timing. The return of **BRYAN**, arriving in Portland following his mother's death, offers the intoxicating comfort of familiar arms and shared history. He makes his intentions clear: he came back for her and Aaliyah, and he's here to stay. Rather than choose between forgiveness and resentment, between Malcolm and Bryan, **LENA** retreats into the one area where she feels control—her work, burying herself in the history of Black Portland for her museum exhibit.
+
+**LENA (V.O.)**
+
+> <mark>"What I need to work on is getting these emotions and my mind to align."</mark> *[p. 195]*
+
+## **<u>ACT TWO</u>**
+
+Unable to maintain her independence, **LENA** and **AALIYAH** move in with **HONEY**, transforming what should have been her sanctuary into a complex battleground of love and control. Every meal becomes a negotiation between Lena's health-conscious restrictions for Aaliyah and Honey's belief that food equals comfort and care. The generational patterns that Lena hoped to break reassert themselves with new intensity. **MALCOLM** relentlessly pursues reconciliation while **BRYAN** makes romantic overtures, leaving Lena trapped between past and future, between safety and risk.
+
+### *Act II - Fun and Games*
+
+**LENA** attempts to navigate her new reality through a series of increasingly complicated relationships. **BRYAN** takes her on dates that feel like time travel, rekindling old chemistry while **HONEY** watches from the sidelines with maternal disapproval, treating Bryan like the high school boyfriend she never trusted.
+
+Meanwhile, the museum forces **LENA** to work alongside **MALCOLM** on salvaging pieces of the Vanport exhibit, creating forced proximity that oscillates between professional efficiency and personal tension. They navigate Portland's cultural bureaucracy together, their shared passion for the project rekindling emotional intimacy even as trust remains fractured.
+
+But it's **HONEY** who becomes the unexpected heart of the Vanport project. When **LENA** discovers that her grandfather was the pastor of the church whose pews survived the flood, **HONEY** steps forward to lead the oral history interviews. Her presence transforms the project—community elders who were hesitant to share their stories with strangers open up to the pastor's granddaughter. **HONEY** becomes the bridge between past and present, conducting interviews that reveal not just the history of Vanport, but the generational trauma of displacement that shaped their family.
+
+The wine nights with **KENDRA** become more frequent and necessary as **LENA** processes her romantic confusion and professional disappointment. Living with **HONEY** returns Lena to childhood dynamics, but now with Aaliyah as witness and participant, creating three-generational tension around food, independence, and love. Honey's well-meaning interference clashes with Lena's determination to parent differently, while Aaliyah absorbs lessons about self-worth, beauty, and the complex relationship between love and control.
+
+**BRYAN**'s presence grows more significant as he integrates himself into their daily routine, helping with Aaliyah and offering the stability that Malcolm's betrayal destroyed. But his return also forces **LENA** to confront why their relationship ended originally and whether desperation makes for good decision-making. The professional collaboration with Malcolm reveals their continued intellectual and emotional compatibility, even as personal trust remains elusive.
+
+### *Midpoint Crisis*
+
+The careful balance **LENA** has maintained explodes when **MALCOLM** reveals the identity of the woman he slept with during their breakup—and worse, that **KENDRA** has known all along. The revelation arrives in an "unsent letter" conversation where Malcolm, desperate to rebuild trust, inadvertently exposes Kendra's betrayal.
+
+It happens during one of their late-night work sessions at the museum, surrounded by artifacts and photographs of Vanport. **MALCOLM** has been trying to write her a letter, something to explain his actions, to ask for forgiveness. But as he reads it aloud to her, searching for the right words, he mentions the woman's name—a local business owner who's been working with the museum on community outreach. And then he says it: "Kendra knew. She styled her for a photo shoot last month. She said she was trying to protect you."
+
+The words hang in the air like smoke. **LENA**'s world tilts on its axis. Not just Malcolm's betrayal, but Kendra's complicity. Her best friend, her sister, had been lying to her face for months.
+
+**LENA** discovers that her best friend, hired as a stylist by the other woman, chose financial security over friendship loyalty. When confronted, **KENDRA**'s justification cuts deep: the affair happened during Malcolm and Lena's breakup, so revealing it wasn't her place, and besides, her business relationship with the woman pays her bills. The double betrayal—romantic and platonic—leaves **LENA** questioning every relationship in her life.
+
+That night, **LENA** sleeps with **BRYAN**. Not out of love, but out of the desperate need to feel something other than this crushing sense of betrayal. It's mechanical, hollow, a way to prove to herself that she can still be wanted, still be desired, even as her world crumbles around her.
+
+### *Act II - Bad Guys Close In*
+
+**LENA**'s support system systematically crumbles as she becomes increasingly isolated and controlling. Her strictness with Aaliyah around food and health becomes obsessive, reflecting her desperate attempt to protect her daughter from the pain she experienced. This creates escalating conflict with **HONEY**, who sees Lena's rigid rules as harmful and herself steps in with lenient alternatives. The tension at home mirrors the professional stress as **LENA** watches her life's work literally packed up and removed from the museum, with Malcolm present as both helper and reminder of personal failure.
+
+The final blow comes when **LENA**'s boss, Dr. Patricia Chen, calls her into her office. They've just finished setting up the entire Vanport exhibit space—the pews are installed, the photographs are hung, the oral histories are recorded. **LENA** is exhausted but triumphant, ready to finally share this history with the world.
+
+Dr. Chen's face is grim. "**LENA**, I'm afraid we're pulling the funding. The board has decided to redirect resources to a more... broadly appealing exhibit. I'm sorry."
+
+**LENA**'s world stops. "But we've done all the work. The community is expecting this. My grandfather's church—"
+
+"I know this is personal for you. But the board feels the Vanport story is too niche, too focused on one community. They want something that will attract a wider audience."
+
+**LENA** stares at her boss, this woman she's worked with for years, who has always supported her work. "When did this happen?"
+
+"This morning. The board met this morning. I'm sorry, **LENA**. I fought for you, but the decision is final."
+
+As **LENA** leaves the museum, her phone rings. It's Aaliyah's school. There's been an incident. Her daughter is in the hospital.
+
+### *Hospital - Aaliyah's Room/Night*
+
+**HONEY** found **AALIYAH** unconscious in the bathroom at school, having taken too many of **LENA**'s appetite suppressants. She rushed her to the hospital, calling **MALCOLM** on the way. When **LENA** arrives, **MALCOLM** is already there, immediately shifting into protective father mode despite their fractured relationship. At the emergency room, **LENA** dismisses him, asking him to handle the museum crisis while promising updates. She finds **HONEY** in the surgical waiting area, both women confronting their worst fears.
+
+**THIS IS WHERE THE OSCAR SCENE FIGHT GOES.**
+
+## **<u>ACT THREE</u>**
+
+Late that night, **LENA** falls asleep curled uncomfortably in the chair beside **AALIYAH**'s bed, her body barely fitting. **HONEY** slips out to the waiting room where she finds **MALCOLM** still there, slumped in a chair. When **HONEY** gently suggests he go home, that they won't know anything until morning, he just shakes his head. This is where he needs to be. She touches his shoulder briefly before leaving—a small gesture of grace.
+
+When **HONEY** returns to **AALIYAH**'s room, she sees **LENA** twisted in that too-small chair, still keeping watch even in sleep. She finds a blanket and gently covers her daughter, smoothing her hair back from her face the way she used to when Lena was small and scared. For a moment, she just stands there in the harsh hospital light, watching over both of them.
+
+### *Morning*
+
+When **KENDRA** arrives at dawn with the care package, having taken the red-eye from New York, **HONEY** meets her in the hallway.
+
+> "She doesn't know I'm here," **KENDRA** says. "But she's my sister. I had to come."
+
+**HONEY** takes the coffee and maple bacon bar from Voodoo Doughnut.
+
+> "She'll know."
+
+**LENA** wakes to find **HONEY** holding out the familiar pink box and coffee.
+
+> "You need to eat."
+
+> "I can't." **LENA**'s eyes are on **AALIYAH**, the monitors. "Not until I know she's—"
+
+> "Eat." **HONEY**'s voice is firm but not unkind.
+
+**LENA** recognizes the pink box immediately.
+
+> "How did you...?"
+
+> "**KENDRA** brought it. Took the red-eye from New York."
+
+**LENA**'s breath catches. After everything between them—
+
+> "Got here an hour ago," **HONEY** continues. "And Malcolm—he's been here all night. In the waiting room. Wouldn't leave."
+
+**LENA** stares at the maple bacon bar, this evidence of people who showed up despite the wreckage between them. Their Sunday tradition, before everything got complicated. Her eyes fill.
+
+> "Listen to me," **HONEY** says, sitting down. "When that little girl wakes up, she's going to need her mother. Not the shell of her mother. You. Strong and present. You can't pour from an empty cup, baby."
+
+**HONEY** continues, her voice softer now:
+
+> <mark>"No one is ever doing it right. Whatever we face, the best any of us can ever do is face it together."</mark> *[p. 354 - adapted for mother-daughter reconciliation]*
+
+> <mark>"It came from a place of protection—I knew badly in my heart what I wanted for you... and I am so, so sorry I didn't know how to want it... for everything I may have gotten wrong, look at you... look at how much I got right. No matter what Aaliyah is going through, no matter what happens—you are a good mother."</mark> *[p. 354 - adapted from Malcolm's dialogue to Honey's maternal wisdom]*
+
+They sit in the morning light. Finally, **LENA** unwraps the maple bacon bar, takes a small bite, then another. **HONEY**'s hand finds her knee.
+
+> "We're going to be okay," **HONEY** says quietly.
+
+When the doctor finally arrives with cautiously optimistic news about **AALIYAH**, **LENA** knows she's not alone. Even broken, even complicated, her people showed up.
+
+### *Finale*
+
+Armed with new understanding about love, forgiveness, and self-worth, **LENA** refuses to let her exhibit disappear quietly. She organizes "Reclaiming Vanport: A Community Celebration"—an alternative showcase that celebrates Black Portland history on her own terms, held at the community center where her grandfather's church once stood. It's a literal and metaphorical reclaiming of space, featuring the salvaged pews, the oral histories **HONEY** collected, and a powerful display of resilience and survival.
+
+The reconciliation with **KENDRA** happens quietly on her porch, with wine and simple honesty. **KENDRA** arrives first, carrying two bottles of wine and a peace offering of **LENA**'s favorite snacks.
+
+> "I came to apologize," **KENDRA** says before **LENA** can speak. "I'm your sister. I should have told you. I shouldn't have put my business before our friendship. I was scared, and I was wrong."
+
+They sit in the evening light, sharing wine and stories, rebuilding the trust that was broken. By the time the second bottle is empty, they're laughing again, and when they hug goodbye, it feels like coming home.
+
+At the exhibit, **LENA** delivers a powerful speech that synthesizes her journey:
+
+> <mark>"I want you all to take a good look at me... See me. All of me... 'Reclaiming Vanport' is about reclaiming our stories, centering our experiences. It is about taking up space."</mark> *[p. 369]*
+
+> <mark>"I speak this out loud so that my humanity is centered more than my accomplishments... I deserve to have a comfortable seat to sit in... I deserve to be heard when I speak up for what I need. And not just me—you deserve it, and so do the members of the community you serve."</mark> *[p. 370]*
+
+### *The Exhibit - With Malcolm*
+
+After **LENA**'s powerful speech about taking up space, the crowd disperses to view the exhibits. Music plays softly. **MALCOLM** finds her by the salvaged church pews.
+
+> "Dance with me?"
+
+They move together, tentative at first. The muscle memory of being partners slowly returns.
+
+> "I know I broke us," he says quietly. "But watching you up there... you're exactly who you're supposed to be. And I want to be the man who deserves that woman."
+
+They're barely swaying now, foreheads almost touching.
+
+> "I bought a purple paint sample," he continues. "For Aaliyah's room. Deep purple, not lavender. She was very specific." His voice catches slightly. "I know I'm not her father yet. Maybe I'll never be. But I want to earn that. I want to earn both of you."
+
+**LENA**'s eyes fill. He pulls back to look at her.
+
+> "I'm not asking you to marry me tonight. But I'm telling you I'm going to. When we're ready. When I've earned it. When you trust me again."
+
+> "Malcolm..." She touches his face. "I never stopped loving you. Even when I hated you, I loved you. That's the scariest part—knowing I could love someone who hurt me that much."
+
+She takes a breath, steadying herself.
+
+> <mark>"But I also know what we had. What we could have again. That Wednesday kind of love—2:26 p.m. on a rainy afternoon, nothing special happening, just us being boring together. That's what I want back."</mark> *[p. 1279]*
+
+> "I want to give you that," he says. "Every ordinary Wednesday. Every boring, beautiful day. The kind of love that shows up for nothing special."
+
+> "Then yes," she says simply. "Yes to trying again. Yes to painting Aaliyah's room. Yes to us."
+
+**MALCOLM** looks at her, his eyes filled with hope:
+
+> <mark>"Ours is a love story still being written. A tattered love knitted together by grace... Thank you for loving me... Will you keep writing our story? Will you marry me?"</mark> *[p. 374]*
+
+**LENA**'s eyes fill with tears as she responds:
+
+> <mark>"Yes, Malcolm. I will marry you. Yes, yes!"</mark> *[p. 374]*
+
+They kiss, still swaying to the music, finding their rhythm again.
+
+### *Later - As the Exhibit Winds Down*
+
+The crowd has thinned. Caterers pack up empty trays. **LENA** stands alone by the salvaged church pews, still taking it all in—this thing she built, this history she refused to let disappear.
+
+**HONEY** approaches quietly, touching one of the pews.
+
+> "Your great-grandfather's congregation would have filled these twice over tonight," she says. "All those faces on the walls—they have names again because of you."
+
+She pauses, choosing her words carefully.
+
+> "We never were good at saying things in our family. The important things."
+
+**LENA** waits, sensing where this is going.
+
+> "My mother never told me she loved me. Not once. She showed it the only way she knew how—by keeping me fed, keeping me safe, keeping me small enough to slip through this world without being noticed."
+
+**LENA** turns to face her mother.
+
+> "So that's what I knew." **HONEY** looks past **LENA**, at the photographs on the wall. "Small meant safe."
+
+A long pause. She still can't quite look at her daughter.
+
+> "I was wrong."
+
+Finally, their eyes meet. **HONEY** nods once—an acknowledgment, a release, a blessing all at once.
+
+**LENA** reaches for her mother's hand. **HONEY** looks down at their intertwined fingers, surprised by the gesture. Then she squeezes back. No more words needed—forgiveness, understanding, love all passing between them in this simple touch.
+
+**LENA** glances across the room to where **AALIYAH** is dancing with **KENDRA**, both of them laughing as **KENDRA** teaches her some old-school move. The music shifts, and people begin to fill the makeshift dance floor again. Still holding **HONEY**'s hand, **LENA** leads her mother toward her daughter.
+
+As they reach **AALIYAH**, **LENA** takes her daughter's hand and looks into her eyes:
+
+> <mark>"Aaliyah, do you know how powerful we are, how powerful you are?"</mark> *[p. 374]*
+
+**LENA'S VOICEOVER:** <mark>"I want to tell **AALIYAH** what I wish I'd always known... Believe the women who are still able to laugh, even after loss and famine and drought and heartbreak. Trust the ones who know how to nurse a wound, who know something about the time it takes for hurting to heal. Believe me when I say, you have to hold on tight to yourself. Keep your mind anchored to what you know to be true. The anchor is me, is **HONEY**, is Aunt Aretha, is every Black woman who came before you and survived. They are holding you too. Their know-how, their not-gon'-let-nobody-turn-us-'round. Their loudness, their pride. Believe those voices above all other voices."</mark> *[p. 5814-5816]*
+
+The three generations come together on the dance floor. Then the camera hones in on **LENA**, dancing freely, expansive and uncontained intercut with shots of Portland, the Vanport flood, but finally, ending on **LENA**'s full embrace of herself, taking up space:
+
+**LENA'S VOICEOVER (CONTINUING):** <mark>"Everything about me is big and Black. Big and majestic like the ocean. Every bit of me hard to contain. My belly spills over and so do my tears and so does my joy and every family recipe and every heartache and every weekend spent at Seaside Beach. It's all here with me."</mark> *[p. 561]*

--- a/Skin_and_Bones_Treatment_v1_WIP_fixed.md
+++ b/Skin_and_Bones_Treatment_v1_WIP_fixed.md
@@ -1,0 +1,1 @@
+# Skin & Bones - Treatment v1 WIP


### PR DESCRIPTION
Correct character name bolding in the treatment to only bold on first introduction and as dialogue speakers.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab877203-83fe-4d3b-a5cf-5f8f8d50fdd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab877203-83fe-4d3b-a5cf-5f8f8d50fdd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

